### PR TITLE
Only check public suffix domains

### DIFF
--- a/lib/riemann/tools/rdap.rb
+++ b/lib/riemann/tools/rdap.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "public_suffix"
 require "rdap"
 
 require "riemann/tools"
@@ -11,8 +12,12 @@ module Riemann
 
       opt :domains, "Domains to monitor", short: :none, type: :strings, default: []
 
+      def public_suffix_domains
+        @public_suffix_domains ||= opts[:domains].map { |d| PublicSuffix.domain(d) }.uniq
+      end
+
       def tick
-        opts[:domains].each do |domain|
+        public_suffix_domains.each do |domain|
           check_domain(domain)
         end
       end

--- a/riemann-rdap.gemspec
+++ b/riemann-rdap.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "public_suffix", "~> 5.0"
   spec.add_dependency "riemann-tools", "~> 1.0"
   spec.add_dependency "rdap", "~> 0.1.5"
 end


### PR DESCRIPTION
For each provided domain name, extract the public suffix domain to
check, and make sure there is no duplicate.

This allows to pass an unfiltered list of domain names like `--domains
example.com www.example.com` and only produce metrics for `example.com`,
ignoring `www.example.com` which would not have RDAP information.
