### PR TITLE
Fix running from riemann-wrapper

### DIFF
--- a/exe/riemann-rdap
+++ b/exe/riemann-rdap
@@ -5,4 +5,4 @@ Process.setproctitle($PROGRAM_NAME)
 
 require "riemann/tools/rdap"
 
-Riemann::Tools::RDAP.run
+Riemann::Tools::Rdap.run

--- a/lib/riemann/tools/rdap.rb
+++ b/lib/riemann/tools/rdap.rb
@@ -7,7 +7,7 @@ require "riemann/tools"
 
 module Riemann
   module Tools
-    class RDAP
+    class Rdap
       include Riemann::Tools
 
       opt :domains, "Domains to monitor", short: :none, type: :strings, default: []
@@ -25,14 +25,14 @@ module Riemann
       end
 
       def check_domain(domain)
-        data = ::RDAP.domain(domain)
+        data = RDAP.domain(domain)
         expiration_date = DateTime.parse(data["events"].find { |e| e["eventAction"] == "expiration" }["eventDate"])
         time_left_days = (expiration_date - DateTime.now).to_i
 
         description = "Domain #{domain} will expire in #{time_left_days} days"
 
         report_expiration(domain, time_left_days, description)
-      rescue ::RDAP::NotFound
+      rescue RDAP::NotFound
         report_expiration(domain, nil, "Domain #{domain} not found")
       end
 

--- a/spec/riemann/rdap_spec.rb
+++ b/spec/riemann/rdap_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe Riemann::Tools::RDAP do
+RSpec.describe Riemann::Tools::Rdap do
   describe "#check_domain" do
     before do
-      allow(::RDAP).to receive(:domain).with("example.com").and_return({
+      allow(RDAP).to receive(:domain).with("example.com").and_return({
         "events" => [
           {"eventAction" => "expiration", "eventDate" => "2021-01-01T00:00:00Z"}
         ]


### PR DESCRIPTION
When running from riemann-wrapper, the class name is infered from the
tool so we must capitalize it, not upcase it.

This fix execution from riemann-wrapper.
